### PR TITLE
Fixing broken `&` functionality when spaceless.nvim enabled

### DIFF
--- a/lua/spaceless.lua
+++ b/lua/spaceless.lua
@@ -37,7 +37,13 @@ local function stripWhitespace(top, bottom)
   local first_changed = vim.fn.getpos("'[")
   local last_changed = vim.fn.getpos("']")
 
-  vim.cmd("silent exe "..top.." ',' "..vim.b.bottom.. " 's/\\v\\s+$//e'")
+  local sourced_text = api.nvim_buf_get_lines(0, top-1, bottom, false)
+  local replaced_text = {}
+  for index, line in ipairs(sourced_text) do
+    local l, _ = string.gsub(line, '%s+$', '')
+    table.insert(replaced_text, index, l)
+  end
+  api.nvim_buf_set_lines(0, top-1, bottom, false, replaced_text)
 
   vim.fn.setpos("']", last_changed)
   vim.fn.setpos("'[", first_changed)


### PR DESCRIPTION
There's a built-in Vim/Neovim functionality of repeating last substitution in current line with `&` key.

Spaceless.nvim has this functionality broken because of using `:s` command internally to strip trailing whitespace, which redefines last replacement command, making `&` non-functional (replaces search match with blank space).

This PR is a quick demo fix for this, it uses Neovim API internally to replace buffer line ranges. I cannot test in extensively now, probably setting buffer to current (0) is a bad idea. Anyway, this is a base for original plugin author to work with.